### PR TITLE
Fix tooltip fallback import

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -306,7 +306,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           state.coreModule.tooltipManager.show(range);
         } else {
           // Fallback tooltip showing
-          import('./tooltip.js').then(module => {
+          const tooltipUrl = chrome.runtime.getURL('modules/tooltip.js');
+          import(tooltipUrl).then(module => {
             if (module && module.createTooltip) {
               module.createTooltip(range, { floatingMenu: true });
             }


### PR DESCRIPTION
## Summary
- use `chrome.runtime.getURL` to load tooltip module fallback in the content script

## Testing
- `node --check scripts/content.js`


------
https://chatgpt.com/codex/tasks/task_e_6843368d06648327822674ba777162b4